### PR TITLE
zero-pad $USER in $DISPLAYNAME

### DIFF
--- a/labsetup/userCreate_SP.sh
+++ b/labsetup/userCreate_SP.sh
@@ -46,7 +46,7 @@ do
    USER=$c
    echo "------"
    #echo "Generating user # "$USER
-   DISPLAY_NAME="${AZ_USER_PREFIX}${USER}"
+   DISPLAY_NAME="${AZ_USER_PREFIX}$(printf %02d $USER)"
    #echo "user name: "$DISPLAY_NAME
    USER_PRINCIPAL="$DISPLAY_NAME@$AZ_USER_DOMAIN"
    #echo "user principal: "$USER_PRINCIPAL


### PR DESCRIPTION
Labs with >= 11 users may encounter a DNS naming conflict. i.e. user 1 will attempt to register both <studentprefix1> and <studentprefix10>, which will conflict with student 10 attempting to register <studentprefix10> and <studentprefix100>. Resolve by zero-padding the user number in the user create script.